### PR TITLE
Start 2025 agenda for FP-SYD talks.

### DIFF
--- a/2025/README.md
+++ b/2025/README.md
@@ -1,0 +1,35 @@
+# Meetings 2024
+
+Talks given and offers of talks for 2025. Please PR with your slides or talk offer as appropriate.
+
+## January
+ - ???
+
+## February
+ - ???
+
+## March
+ - ???
+
+## April
+ - ???
+
+## May
+ - ???
+
+## June
+ - ???
+
+## July
+ - ???
+
+## August
+   
+## September
+ - ???
+
+## October
+ - ???
+
+## November
+ - ???

--- a/2025/README.md
+++ b/2025/README.md
@@ -1,4 +1,4 @@
-# Meetings 2024
+# Meetings 2025
 
 Talks given and offers of talks for 2025. Please PR with your slides or talk offer as appropriate.
 

--- a/2025/README.md
+++ b/2025/README.md
@@ -3,6 +3,7 @@
 Talks given and offers of talks for 2025. Please PR with your slides or talk offer as appropriate.
 
 ## January
+- Geoffrey Borough: On OCaml
  - ???
 
 ## February


### PR DESCRIPTION
List of people who put their hand up to provide talks next year:
* Huw Campbell (maybe lightning in Feb, March)
* Amos Robinson (May)
* ~~Vaibhav Sagar (Feb)~~
* Mark Hopkins
* Jost Berthold (not April)
* Tim McGilchrist (not ICFP)  (June)
* Jonathan Merritt
* Alex Mason
* Ivan ???
* ~~Geoffrey Borough (either Jan / Feb)~~
* Thomas Sewell
* John Ky (not Feb or March)
* Carlos Yago
* Burin Choomnuan
* Chris Armstrong (maybe)
* Damian Jurd (maybe)

Workshop session in April.
 